### PR TITLE
Add Spanish doc plan

### DIFF
--- a/docs/plan-implementacion-documentacion.md
+++ b/docs/plan-implementacion-documentacion.md
@@ -1,0 +1,39 @@
+# Plan de Implementación de la Documentación
+
+Este documento describe los pasos iniciales para organizar y completar la documentación del proyecto **Torrent VideoClub Android**.
+
+## Objetivos
+
+1. Compilar guías claras que permitan compilar y ejecutar la aplicación.
+2. Documentar las características principales y el funcionamiento de la API.
+3. Mantener una estructura sencilla basada en Markdown dentro del directorio `docs/`.
+
+## Estructura Propuesta
+
+- `android-project-guide.md` – Guía de compilación e instalación de la app.
+- `backend-api-reference.md` – Referencia de rutas API usadas por el cliente.
+- `project-features-overview.md` – Resumen de características disponibles.
+- `remote-navigation-summary.md` – Consejos de navegación con mando a distancia.
+- `plan-implementacion-documentacion.md` – (este archivo) Pasos para continuar la documentación.
+
+## Pasos Iniciales
+
+1. **Revisión de Documentos Existentes**
+   - Leer los archivos actuales en `docs/` para evitar duplicaciones.
+2. **Lista de Temas Faltantes**
+   - Autenticación y configuración avanzada.
+   - Ejemplos de flujo de trabajo (añadir series o películas, etc.).
+   - Sección de preguntas frecuentes.
+3. **Asignación de Responsables**
+   - Definir quién redactará cada sección y establecer fechas límite.
+4. **Integración Continua**
+   - Incluir revisiones de documentación en el flujo de Pull Requests.
+5. **Publicación**
+   - Explorar la generación de un sitio estático usando herramientas como GitHub Pages.
+
+## Siguientes Pasos
+
+- Crear un listado detallado de los temas pendientes.
+- Definir un calendario para completarlos.
+- Revisar periódicamente la documentación para mantenerla actualizada con los cambios del proyecto.
+


### PR DESCRIPTION
## Summary
- document the implementation plan in Spanish

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f81d8f4c8325a34f75356754e5ee