### PR TITLE
Add featured home screen with carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,11 @@ This repository contains the initial setup for a **native Android** client of [T
 4. Update `ApiClient.kt` with your backend server URL.
 5. Run the **app** configuration to build and deploy the APK on a device or emulator.
    If using the command line, run `gradle wrapper` once to generate `gradle/wrapper/gradle-wrapper.jar` before executing `./gradlew`.
+6. With the SDK configured locally you can trigger a build from the terminal:
+   ```bash
+   ./gradlew assembleDebug
+   ```
+
+The current build includes a featured home screen with a central carousel and Netflix-style category rows. Ensure your backend exposes `/api/featured` and `/api/featured/carousel-content` so the screen can load data.
 
 See `docs/android-project-guide.md` for more details.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,10 +42,14 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0'
     implementation platform('androidx.compose:compose-bom:2024.05.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.activity:activity-compose:1.9.0'
+    implementation 'androidx.compose.foundation:foundation'
+    implementation 'androidx.compose.material3:material3'
+    implementation 'io.coil-kt:coil-compose:2.5.0'
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.torrentclub.app">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/app/src/main/java/com/torrentclub/app/FeaturedViewModel.kt
+++ b/app/src/main/java/com/torrentclub/app/FeaturedViewModel.kt
@@ -1,0 +1,44 @@
+package com.torrentclub.app
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.torrentclub.app.model.CarouselItem
+import com.torrentclub.app.model.Category
+import com.torrentclub.app.network.ApiService
+import kotlinx.coroutines.launch
+
+class FeaturedViewModel : ViewModel() {
+    var carouselItems by mutableStateOf<List<CarouselItem>>(emptyList())
+        private set
+
+    var categories by mutableStateOf<List<Category>>(emptyList())
+        private set
+
+    var isLoading by mutableStateOf(true)
+        private set
+
+    var error by mutableStateOf<String?>(null)
+        private set
+
+    private val api = ApiClient.retrofit.create(ApiService::class.java)
+
+    init {
+        viewModelScope.launch { loadData() }
+    }
+
+    private suspend fun loadData() {
+        try {
+            isLoading = true
+            carouselItems = api.getCarousel()
+            categories = api.getFeatured()
+            error = null
+        } catch (e: Exception) {
+            error = e.message
+        } finally {
+            isLoading = false
+        }
+    }
+}

--- a/app/src/main/java/com/torrentclub/app/MainActivity.kt
+++ b/app/src/main/java/com/torrentclub/app/MainActivity.kt
@@ -5,28 +5,15 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import com.torrentclub.app.ui.FeaturedScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             Surface(color = MaterialTheme.colorScheme.background) {
-                Greeting()
+                FeaturedScreen()
             }
         }
     }
-}
-
-@Composable
-fun Greeting() {
-    Text(text = "Hello TorrentClub!")
-}
-
-@Preview
-@Composable
-fun DefaultPreview() {
-    Greeting()
 }

--- a/app/src/main/java/com/torrentclub/app/model/CarouselItem.kt
+++ b/app/src/main/java/com/torrentclub/app/model/CarouselItem.kt
@@ -1,0 +1,12 @@
+package com.torrentclub.app.model
+
+import com.google.gson.annotations.SerializedName
+
+data class CarouselItem(
+    @SerializedName("tmdbId") val tmdbId: Int,
+    val title: String?,
+    @SerializedName("posterPath") val posterPath: String?,
+    @SerializedName("backdropPath") val backdropPath: String?,
+    val overview: String?,
+    val mediaType: String
+)

--- a/app/src/main/java/com/torrentclub/app/model/Category.kt
+++ b/app/src/main/java/com/torrentclub/app/model/Category.kt
@@ -1,0 +1,10 @@
+package com.torrentclub.app.model
+
+import com.google.gson.annotations.SerializedName
+
+/** Category of featured items */
+data class Category(
+    val id: String,
+    val title: String,
+    val items: List<TmdbItem>
+)

--- a/app/src/main/java/com/torrentclub/app/model/TmdbItem.kt
+++ b/app/src/main/java/com/torrentclub/app/model/TmdbItem.kt
@@ -1,0 +1,12 @@
+package com.torrentclub.app.model
+
+import com.google.gson.annotations.SerializedName
+
+data class TmdbItem(
+    @SerializedName("tmdbId") val tmdbId: Int,
+    val title: String?,
+    @SerializedName("posterPath") val posterPath: String?,
+    @SerializedName("backdropPath") val backdropPath: String?,
+    val overview: String?,
+    val mediaType: String
+)

--- a/app/src/main/java/com/torrentclub/app/network/ApiService.kt
+++ b/app/src/main/java/com/torrentclub/app/network/ApiService.kt
@@ -1,0 +1,13 @@
+package com.torrentclub.app.network
+
+import com.torrentclub.app.model.CarouselItem
+import com.torrentclub.app.model.Category
+import retrofit2.http.GET
+
+interface ApiService {
+    @GET("api/featured/carousel-content")
+    suspend fun getCarousel(): List<CarouselItem>
+
+    @GET("api/featured")
+    suspend fun getFeatured(): List<Category>
+}

--- a/app/src/main/java/com/torrentclub/app/ui/CategoryRow.kt
+++ b/app/src/main/java/com/torrentclub/app/ui/CategoryRow.kt
@@ -1,0 +1,36 @@
+package com.torrentclub.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.torrentclub.app.model.Category
+
+@Composable
+fun CategoryRow(category: Category) {
+    Text(
+        text = category.title,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    )
+
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.height(180.dp)
+    ) {
+        items(category.items) { item ->
+            MediaCard(item, modifier = Modifier.height(180.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/torrentclub/app/ui/FeaturedCarousel.kt
+++ b/app/src/main/java/com/torrentclub/app/ui/FeaturedCarousel.kt
@@ -1,0 +1,68 @@
+package com.torrentclub.app.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.torrentclub.app.model.CarouselItem
+import kotlinx.coroutines.launch
+
+private const val TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/"
+
+@Composable
+fun FeaturedCarousel(items: List<CarouselItem>) {
+    val pagerState = rememberPagerState()
+    Box(modifier = Modifier
+        .fillMaxWidth()
+        .height(240.dp)) {
+        HorizontalPager(pageCount = items.size, state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+            val item = items[page]
+            val imageUrl = item.backdropPath?.let {
+                if (it.startsWith("http")) it else TMDB_IMAGE_BASE_URL + "w780" + it
+            } ?: item.posterPath?.let {
+                if (it.startsWith("http")) it else TMDB_IMAGE_BASE_URL + "w500" + it
+            }
+            Box(modifier = Modifier.fillMaxSize()) {
+                if (imageUrl != null) {
+                    AsyncImage(
+                        model = imageUrl,
+                        contentDescription = item.title,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(Color.Black.copy(alpha = 0.6f), Color.Transparent)
+                            )
+                        )
+                )
+                Box(modifier = Modifier.align(Alignment.BottomStart).padding(16.dp)) {
+                    Text(
+                        text = item.title ?: "",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = Color.White
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/torrentclub/app/ui/FeaturedScreen.kt
+++ b/app/src/main/java/com/torrentclub/app/ui/FeaturedScreen.kt
@@ -1,0 +1,43 @@
+package com.torrentclub.app.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.torrentclub.app.FeaturedViewModel
+
+@Composable
+fun FeaturedScreen(viewModel: FeaturedViewModel = viewModel()) {
+    val isLoading = viewModel.isLoading
+    val error = viewModel.error
+    val carouselItems = viewModel.carouselItems
+    val categories = viewModel.categories
+
+    when {
+        isLoading -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+        error != null -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(text = error ?: "Error", color = MaterialTheme.colorScheme.error)
+        }
+        else -> {
+            LazyColumn {
+                item {
+                    if (carouselItems.isNotEmpty()) {
+                        FeaturedCarousel(carouselItems)
+                    }
+                }
+                items(categories) { category ->
+                    CategoryRow(category)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/torrentclub/app/ui/MediaCard.kt
+++ b/app/src/main/java/com/torrentclub/app/ui/MediaCard.kt
@@ -1,0 +1,41 @@
+package com.torrentclub.app.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.compose.rememberAsyncImagePainter
+import com.torrentclub.app.model.TmdbItem
+
+private const val TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/"
+
+@Composable
+fun MediaCard(item: TmdbItem, modifier: Modifier = Modifier) {
+    val imageUrl = item.posterPath?.let {
+        if (it.startsWith("http")) it else TMDB_IMAGE_BASE_URL + "w342" + it
+    }
+
+    Card(
+        modifier = modifier
+            .fillMaxHeight()
+            .clip(RoundedCornerShape(6.dp)),
+        colors = CardDefaults.cardColors()
+    ) {
+        if (imageUrl != null) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = item.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxWidth().fillMaxHeight()
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="neon_pink">#FF007A</color>
+    <color name="neon_cyan">#00FFFF</color>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Theme.TorrentClub" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/neon_pink</item>
+        <item name="colorSecondary">@color/neon_cyan</item>
     </style>
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- add API service and models for featured content
- implement `FeaturedViewModel`
- create Compose UI for carousel, media cards and category rows
- hook new screen into `MainActivity`
- add colors and theme tweaks
- document the new home screen in README
- describe `./gradlew assembleDebug` in README

## Testing
- `gradle wrapper --gradle-version 8.2 --no-daemon`
- `./gradlew assembleDebug --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432a26e0b08325bde2254f5296245c