### PR TITLE
Add build startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This repository contains the initial setup for a **native Android** client of [T
    ```bash
    ./gradlew assembleDebug
    ```
+7. Alternatively run the helper script to download the Android SDK and build in
+   one step:
+   ```bash
+   ./build_startup.sh
+   ```
 
 The current build includes a featured home screen with a central carousel and Netflix-style category rows. Ensure your backend exposes `/api/featured` and `/api/featured/carousel-content` so the screen can load data.
 

--- a/build_startup.sh
+++ b/build_startup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directory for the Android SDK
+ANDROID_SDK_ROOT="$HOME/android-sdk"
+CMDLINE_TOOLS_VERSION="10406996"
+TOOLS_ZIP="commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+TOOLS_URL="https://dl.google.com/android/repository/${TOOLS_ZIP}"
+
+if [ ! -d "$ANDROID_SDK_ROOT" ]; then
+  mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+  echo "Downloading Android command line tools..."
+  curl -L "$TOOLS_URL" -o "$TOOLS_ZIP"
+  unzip -q "$TOOLS_ZIP" -d "$ANDROID_SDK_ROOT/cmdline-tools"
+  mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+  rm "$TOOLS_ZIP"
+fi
+
+export ANDROID_HOME="$ANDROID_SDK_ROOT"
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
+
+# Install required SDK components
+yes | sdkmanager --licenses >/dev/null
+sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0" >/dev/null
+
+# Generate Gradle wrapper JAR if missing
+if [ ! -f gradle/wrapper/gradle-wrapper.jar ]; then
+  gradle wrapper
+fi
+
+# Run the build
+./gradlew assembleDebug


### PR DESCRIPTION
## Summary
- add `build_startup.sh` script to automate SDK setup and build
- document the helper script in README

## Testing
- `bash -n build_startup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6844430dc21883259984854ffe13fa78